### PR TITLE
Fix Windows scans TSV crash

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
 # -- Project information -----------------------------------------------------

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -535,9 +535,9 @@ def add_rows_to_scans_keys_file(fn: str, newrows: dict[str, list[str]]) -> None:
       extra rows to add (acquisition time, referring physician, random string)
     """
     if op.lexists(fn):
-        with open(fn, "r") as csvfile:
+        with open(fn, "r", newline="") as csvfile:
             reader = csv.reader(csvfile, delimiter="\t")
-            existing_rows = [row for row in reader]
+            existing_rows = [row for row in reader if row]
         # skip header
         fnames2info = {row[0]: row[1:] for row in existing_rows[1:]}
 
@@ -560,8 +560,8 @@ def add_rows_to_scans_keys_file(fn: str, newrows: dict[str, list[str]]) -> None:
         lgr.warning("Sorting scans by date failed: %s", str(exc))
         data_rows_sorted = sorted(data_rows)
     # save
-    with open(fn, "a") as csvfile:
-        writer = csv.writer(csvfile, delimiter="\t")
+    with open(fn, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile, delimiter="\t", lineterminator="\n")
         writer.writerows([header] + data_rows_sorted)
 
 


### PR DESCRIPTION
## Summary
- fix reading/writing of _scans.tsv to handle blank rows and use correct newline handling
- make docs build config import project by ensuring repository root is on `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa467514083268ce5dd65209e2b00