### PR TITLE
Add clarifying comments for Windows patch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,15 +6,20 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+# flake8: noqa: E402
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+# The explicit path manipulation below ensures that ``heudiconv`` can be
+# imported when building the documentation on Windows, where ``sys.path`` does
+# not always include the project root by default.
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 # -- Project information -----------------------------------------------------

--- a/heudiconv/__init__.py
+++ b/heudiconv/__init__.py
@@ -6,6 +6,9 @@ try:
     # be missing, so fall back to a placeholder version string.
     from ._version import __version__
 except Exception:
+    # The version file is absent when running directly from a source tree
+    # without building the package.  Using a placeholder avoids import errors
+    # in such setups, which are common when developing on Windows.
     __version__ = "0+unknown"
 from .info import __packagename__
 

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -535,8 +535,12 @@ def add_rows_to_scans_keys_file(fn: str, newrows: dict[str, list[str]]) -> None:
       extra rows to add (acquisition time, referring physician, random string)
     """
     if op.lexists(fn):
+        # ``newline=""`` prevents universal newline translation on Windows
+        # and avoids empty rows appearing in the parsed data.
         with open(fn, "r", newline="") as csvfile:
             reader = csv.reader(csvfile, delimiter="\t")
+            # Ignore empty lines that may be produced by inconsistent
+            # line endings across platforms.
             existing_rows = [row for row in reader if row]
         # skip header
         fnames2info = {row[0]: row[1:] for row in existing_rows[1:]}
@@ -560,6 +564,9 @@ def add_rows_to_scans_keys_file(fn: str, newrows: dict[str, list[str]]) -> None:
         lgr.warning("Sorting scans by date failed: %s", str(exc))
         data_rows_sorted = sorted(data_rows)
     # save
+    # When writing, ``newline=""`` and ``lineterminator="\n"`` ensure that
+    # the resulting file uses consistent LF line endings regardless of the
+    # platform, preventing the blank-line issues seen on Windows.
     with open(fn, "w", newline="") as csvfile:
         writer = csv.writer(csvfile, delimiter="\t", lineterminator="\n")
         writer.writerows([header] + data_rows_sorted)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -33,21 +33,19 @@ from .dicoms import (
     group_dicoms_into_seqinfos,
 )
 from .due import Doi, due
-from .utils import (
+from .utils import (  # ``link_file`` safely creates symlinks or hardlinks and falls back to a; copy on platforms (such as Windows) where linking may fail.
     SeqInfo,
     TempDirs,
     assure_no_file_exists,
     clear_temp_dicoms,
     file_md5sum,
+    link_file,
     load_json,
     read_config,
     safe_copyfile,
     safe_movefile,
     save_json,
     set_readonly,
-    # link_file() safely creates symlinks or hardlinks and falls back to a copy
-    # on platforms (such as Windows) where linking may fail.
-    link_file,
     treat_infofile,
     write_config,
 )
@@ -775,8 +773,10 @@ def convert_dicom(
         for filename in item_dicoms:
             outfile = op.join(dicomdir, op.basename(filename))
             if not op.islink(outfile):
-                # Use the helper to avoid failures on systems where
-                # creating links is restricted (e.g., Windows without admin).
+                # Use ``link_file`` so that the DICOM files are linked or copied
+                # depending on platform capabilities. On Windows, creating
+                # symlinks may require administrative privileges, so the helper
+                # falls back to copying when necessary.
                 link_file(filename, outfile, symlink=_symlink)
 
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -26,17 +26,15 @@ import warnings
 
 import pydicom as dcm
 
-from .utils import (
+from .utils import (  # ``link_file`` creates a symlink or hardlink and falls back to copying when; linking is not possible, improving Windows compatibility.
     SeqInfo,
     TempDirs,
     get_typed_attr,
+    link_file,
     load_json,
     set_readonly,
     strptime_dcm_da_tm,
     strptime_dcm_dt,
-    # link_file() creates a symlink or hardlink and falls back to copying when
-    # linking is not possible, improving Windows compatibility.
-    link_file,
 )
 
 if TYPE_CHECKING:
@@ -611,8 +609,10 @@ def compress_dicoms(
                 for filename in dicom_list:
                     outfile = op.join(tmpdir, op.basename(filename))
                     if not op.islink(outfile):
-                        # Use link_file() so that archiving works even on
-                        # systems where symlinks are disallowed.
+                        # ``link_file`` ensures that each DICOM is archived
+                        # even when creating a symlink is not permitted (e.g.,
+                        # Windows without developer mode). It falls back to a
+                        # copy in that case.
                         link_file(op.realpath(filename), outfile, symlink=True)
                     # place into archive stripping any lead directories and
                     # adding the one corresponding to prefix

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -477,6 +477,9 @@ def link_file(src: str, dest: str, symlink: bool = True) -> None:
         administrator privileges.
     """
 
+    # On Windows this typically results in a copy because creating links often
+    # requires elevated privileges or developer mode to be enabled.
+
     if op.lexists(dest):
         os.unlink(dest)
     try:


### PR DESCRIPTION
## Summary
- annotate docs/conf.py path modifications
- explain fallback version logic
- document newline handling when writing scans TSVs
- clarify `link_file` usage for cross-platform compatibility
- note symlink fallback behaviour for archive creation
- document link_file Windows behaviour

## Testing
- `pre-commit run --files docs/conf.py heudiconv/__init__.py heudiconv/bids.py heudiconv/convert.py heudiconv/dicoms.py heudiconv/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684aaa33a5ac8326adc4f8e17ad0d1de