### PR TITLE
Fix pip install by adding default tag for versioningit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.versioningit.write]
 file = "heudiconv/_version.py"
+
+[tool.versioningit.vcs]
+default-tag = "0.0.0"


### PR DESCRIPTION
## Summary
- set `versioningit` default tag to allow installation from a repo with no tags

## Testing
- `pip install --no-deps -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684adb3f8fc083268b181664ab5ea3c8