### PR TITLE
Fix Windows read-only error in post processing

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -687,7 +687,11 @@ def convert(
         # this may not always be the case: ex. fieldmap1, fieldmap2
         # will address after refactor
         if outname and op.exists(outname):
-            set_readonly(outname)
+            if os.name != "nt":
+                # Avoid setting the read-only flag on Windows because it
+                # prevents subsequent runs with ``--overwrite`` from cleaning up
+                # previous outputs.
+                set_readonly(outname)
 
         if custom_callable is not None:
             custom_callable(*item)

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -369,7 +369,12 @@ def treat_infofile(filename: str) -> None:
     j = load_json(filename)
     j_slim = slim_down_info(j)
     save_json(filename, j_slim, sort_keys=True, pretty=True)
-    set_readonly(filename)
+    if os.name != "nt":
+        # On Windows, making files read-only prevents later overwrite and leads
+        # to permission errors when rerunning conversions.  Only set the flag
+        # on non-Windows platforms where it helps guard against accidental
+        # edits without interfering with cleanup.
+        set_readonly(filename)
 
 
 def slim_down_info(j: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- revert removal patch
- avoid setting read-only flag on Windows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c16f568e0832688091a15500b8b1d