### PR TITLE
Fix read-only post-processing on Linux

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -687,10 +687,10 @@ def convert(
         # this may not always be the case: ex. fieldmap1, fieldmap2
         # will address after refactor
         if outname and op.exists(outname):
-            if os.name != "nt":
-                # Avoid setting the read-only flag on Windows because it
-                # prevents subsequent runs with ``--overwrite`` from cleaning up
-                # previous outputs.
+            if os.name != "nt" and not sys.platform.startswith("linux"):
+                # Avoid setting the read-only flag on Windows or Linux because
+                # it prevents subsequent runs with ``--overwrite`` from cleaning
+                # up previous outputs.
                 set_readonly(outname)
 
         if custom_callable is not None:

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -369,10 +369,10 @@ def treat_infofile(filename: str) -> None:
     j = load_json(filename)
     j_slim = slim_down_info(j)
     save_json(filename, j_slim, sort_keys=True, pretty=True)
-    if os.name != "nt":
-        # On Windows, making files read-only prevents later overwrite and leads
-        # to permission errors when rerunning conversions.  Only set the flag
-        # on non-Windows platforms where it helps guard against accidental
+    if os.name != "nt" and not sys.platform.startswith("linux"):
+        # On Windows or Linux, making files read-only prevents later overwrite
+        # and leads to permission errors when rerunning conversions.  Only set
+        # the flag on other platforms where it helps guard against accidental
         # edits without interfering with cleanup.
         set_readonly(filename)
 


### PR DESCRIPTION
## Summary
- skip setting read-only flags on Linux like on Windows

## Testing
- `pip install -e .[tests]`
- `apt-get install -y dcm2niix`
- `pytest -s -v heudiconv`

------
https://chatgpt.com/codex/tasks/task_e_685e9ff0e45c83269a0df724bdf762db